### PR TITLE
Update bower dependencies

### DIFF
--- a/src/main/webapp/frontend/bower.json
+++ b/src/main/webapp/frontend/bower.json
@@ -33,12 +33,15 @@
     "paper-tabs": "~2.0.0",
     "paper-toolbar": "~2.0.0",
     "paper-tooltip": "~2.0.0",
-    "vaadin-text-field": "~1.1.0-alpha3",
-    "vaadin-button": "~1.0.0",
-    "vaadin-checkbox": "~1.0.0-alpha2",
-    "vaadin-combo-box": "~2.0.0",
-    "vaadin-form-layout": "~1.0.0",
-    "vaadin-split-layout": "~3.0.0-alpha1",
-    "vaadin-date-picker": "~2.0.2"
+    "vaadin-grid": "~4.0.0-alpha2",
+    "vaadin-text-field": "~1.1.0-beta1",
+    "vaadin-button": "~1.0.4",
+    "vaadin-checkbox": "~1.0.0-beta1",
+    "vaadin-combo-box": "~3.0.0-alpha7",
+    "vaadin-form-layout": "~1.0.3",
+    "vaadin-split-layout": "~3.0.0-beta1",
+    "vaadin-date-picker": "~2.0.5",
+    "vaadin-dialog": "~1.0.0-beta1",
+    "vaadin-icons": "~4.1.1"
   }
 }


### PR DESCRIPTION
Vaadin elements now have the same version as in the Flow components demo. Also added vaadin-grid, vaadin-dialog and vaadin-icons.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/skeleton-starter-flow/30)
<!-- Reviewable:end -->
