### PR TITLE
Don't override managed version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,6 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-core</artifactId>
-            <version>${vaadin.version}</version>
         </dependency>
 
         <!-- Added to provide logging output as Flow uses -->


### PR DESCRIPTION
`vaadin.version` is already used for `vaadin-core` by `vaadin-bom`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/skeleton-starter-flow/83)
<!-- Reviewable:end -->
