### PR TITLE
Do not show Atmosphere debug (info) output by default

### DIFF
--- a/src/main/resources/simplelogger.properties
+++ b/src/main/resources/simplelogger.properties
@@ -1,0 +1,2 @@
+org.slf4j.simpleLogger.defaultLogLevel = info
+org.slf4j.simpleLogger.log.org.atmosphere = warn


### PR DESCRIPTION
Depends on https://github.com/vaadin/flow/pull/5818

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/skeleton-starter-flow/176)
<!-- Reviewable:end -->
