### PR TITLE
Added missing jetty configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <failOnMissingWebXml>false</failOnMissingWebXml>
 
         <vaadin.version>13.0.8</vaadin.version>
@@ -157,6 +158,9 @@
                         <version>9.4.15.v20190215</version>
                         <configuration>
                             <scanIntervalSeconds>0</scanIntervalSeconds>
+                            <stopKey>${project.artifactId}</stopKey>
+                            <stopPort>8081</stopPort>
+                            <stopWait>5</stopWait>
                         </configuration>
                         <executions>
                             <execution>


### PR DESCRIPTION
`integration-tests` profile's jetty was missing stopXXX configurations

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/skeleton-starter-flow/182)
<!-- Reviewable:end -->
