### PR TITLE
chore: update Jetty version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
         <vaadin.version>19.0.0.alpha3</vaadin.version>
         <drivers.downloader.phase>pre-integration-test</drivers.downloader.phase>
-        <jetty.version>9.4.28.v20200408</jetty.version>
+        <jetty.version>9.4.36.v20210114</jetty.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
Fixes vaadin/flow#9809

Jetty had an FS change scanning issue on Windows, that results in restarting
the application during frontend build of Flow (e. g., when Flow build
generates frontend input sources), causing a build loop.

This change updates the Jetty version number to the latest 9.4.x, where
the scanning issue is fixed.

See also: https://github.com/eclipse/jetty.project/issues/2266