### PR TITLE
fix: Jetty 11 maven plugin properties update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,11 +138,11 @@
                     <!-- If using IntelliJ IDEA with autocompilation, this
                     might cause lots of unnecessary compilations in the
                     background.-->
-                    <scanIntervalSeconds>2</scanIntervalSeconds>
+                    <scan>2</scan>
                     <!-- Use war output directory to get the webpack files -->
-                    <webAppConfig>
+                    <webApp>
                         <allowDuplicateFragmentNames>true</allowDuplicateFragmentNames>
-                    </webAppConfig>
+                    </webApp>
                 </configuration>
             </plugin>
 
@@ -202,7 +202,7 @@
                         <artifactId>jetty-maven-plugin</artifactId>
                         <version>${jetty.version}</version>
                         <configuration>
-                            <scanIntervalSeconds>0</scanIntervalSeconds>
+                            <scan>0</scan>
                             <stopPort>8081</stopPort>
                             <stopWait>5</stopWait>
                             <stopKey>${project.artifactId}</stopKey>


### PR DESCRIPTION
## Description
Update jetty maven plugin properties in line with Jetty 11

Details on https://www.eclipse.org/jetty/documentation/jetty-11/programming_guide.php

This should be also applied to all other starters / examples moving from Jetty 9 to 11...