### PR TITLE
fix: Exclude development dependencies from production jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,19 @@
             <!-- Production mode is activated using -Pproduction -->
             <id>production</id>
 
+            <dependencies>
+                <!-- Exclude development dependencies from production -->
+                <dependency>
+                    <groupId>com.vaadin</groupId>
+                    <artifactId>vaadin-core</artifactId>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>com.vaadin</groupId>
+                            <artifactId>vaadin-dev</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+            </dependencies>
             <build>
                 <plugins>
                     <plugin>


### PR DESCRIPTION
For https://github.com/vaadin/flow/issues/15749
