### PR TITLE
chore: Upgrade proj4 from 2.8.1 to 2.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -125,7 +125,7 @@
         "construct-style-sheets-polyfill": "3.1.0",
         "date-fns": "2.29.3",
         "lit": "2.6.1",
-        "proj4": "2.8.1"
+        "proj4": "2.9.0"
       },
       "devDependencies": {
         "@rollup/plugin-replace": "3.1.0",
@@ -6056,9 +6056,9 @@
       }
     },
     "node_modules/proj4": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.8.1.tgz",
-      "integrity": "sha512-KK/bgM6oIwxdpeCaJ/JK3V1D8LMQCKKKzndab4/pYQNd+NVKTcddUNtds053Q110GxTALXVjx98L9f5q8xPVXQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.9.0.tgz",
+      "integrity": "sha512-BoDXEzCVnRJVZoOKA0QHTFtYoE8lUxtX1jST38DJ8U+v1ixY70Kpwi0Llu6YqSWEH2xqu4XMEBNGcgeRIEywoA==",
       "dependencies": {
         "mgrs": "1.0.0",
         "wkt-parser": "^1.3.1"
@@ -11834,9 +11834,9 @@
       "dev": true
     },
     "proj4": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.8.1.tgz",
-      "integrity": "sha512-KK/bgM6oIwxdpeCaJ/JK3V1D8LMQCKKKzndab4/pYQNd+NVKTcddUNtds053Q110GxTALXVjx98L9f5q8xPVXQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.9.0.tgz",
+      "integrity": "sha512-BoDXEzCVnRJVZoOKA0QHTFtYoE8lUxtX1jST38DJ8U+v1ixY70Kpwi0Llu6YqSWEH2xqu4XMEBNGcgeRIEywoA==",
       "requires": {
         "mgrs": "1.0.0",
         "wkt-parser": "^1.3.1"

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "construct-style-sheets-polyfill": "3.1.0",
     "date-fns": "2.29.3",
     "lit": "2.6.1",
-    "proj4": "2.8.1"
+    "proj4": "2.9.0"
   },
   "devDependencies": {
     "@rollup/plugin-replace": "3.1.0",
@@ -277,7 +277,7 @@
       "workbox-core": "6.5.4",
       "workbox-precaching": "6.5.4"
     },
-    "hash": "b6ca9f9decd5fa40a00c7d84c890545ce437106a7f503547de1cbb1b84e5f7c8"
+    "hash": "f4a073071e554144c6fcc7bfae06e1197e65446c10634a5824d3bdebe224b8b5"
   },
   "overrides": {
     "@vaadin/accordion": "$@vaadin/accordion",


### PR DESCRIPTION
Recreated the change in #678 due to unresolvable conflicts in package-lock.json