### PR TITLE
chore: Upgrade webdrivermanager to 5.6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>5.0.3</version>
+            <version>5.6.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
## Description

This upgrade is needed to prevent issues with the license checker used in commercial Vaadin products.

Fixes #773 