### PR TITLE
chore: PiT - Update to Vaadin v24.4.0.alpha8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <failOnMissingWebXml>false</failOnMissingWebXml>
 
-        <vaadin.version>24.3.6</vaadin.version>
+        <vaadin.version>24.4.0.alpha8</vaadin.version>
         <drivers.downloader.phase>pre-integration-test</drivers.downloader.phase>
         <jetty.version>11.0.14</jetty.version>
     </properties>
@@ -90,6 +90,12 @@
             <groupId>com.vaadin</groupId>
             <!-- Replace artifactId with vaadin-core to use only free components -->
             <artifactId>vaadin</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.vaadin</groupId>
+                    <artifactId>hilla-dev</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Added to provide logging output as Vaadin uses -->


### PR DESCRIPTION
Created by PiT Script when testing v24.4.0.alpha8. Do not merge until .0 GA is released