### PR TITLE
chore: build production package by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ There is also a [getting started tutorial](https://vaadin.com/tutorials/getting-
 
 To access it directly from github, clone the repository and import the project to the IDE of your choice as a Maven project. You need to have Java 8 or 11 installed.
 
-Run in development mode using `mvn jetty:run -Pdevelopment` and open [http://localhost:8080](http://localhost:8080) in the browser.
+Run in development mode using `mvn jetty:run` and open [http://localhost:8080](http://localhost:8080) in the browser.
 
-If you want to run your app locally in the production mode, run `mvn jetty:run`.
+If you want to run your app locally in the production mode, run `mvn jetty:run -Pproduction`.
 
 ### Running Integration Tests
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ There is also a [getting started tutorial](https://vaadin.com/tutorials/getting-
 
 To access it directly from github, clone the repository and import the project to the IDE of your choice as a Maven project. You need to have Java 8 or 11 installed.
 
-Run using `mvn jetty:run` and open [http://localhost:8080](http://localhost:8080) in the browser.
+Run in development mode using `mvn jetty:run -Pdevelopment` and open [http://localhost:8080](http://localhost:8080) in the browser.
 
-If you want to run your app locally in the production mode, run `mvn jetty:run -Pproduction`.
+If you want to run your app locally in the production mode, run `mvn jetty:run`.
 
 ### Running Integration Tests
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <failOnMissingWebXml>false</failOnMissingWebXml>
 
-        <vaadin.version>25.0.0-beta5</vaadin.version>
+        <vaadin.version>25.0.0-beta6</vaadin.version>
         <jetty.version>12.1.2</jetty.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <failOnMissingWebXml>false</failOnMissingWebXml>
 
-        <vaadin.version>25.0-SNAPSHOT</vaadin.version>
+        <vaadin.version>25.0.0-beta5</vaadin.version>
         <jetty.version>12.1.2</jetty.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,12 @@
             <artifactId>vaadin</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-dev</artifactId>
+            <optional>true</optional>
+        </dependency>
+
         <!-- Added to provide logging output as Vaadin uses -->
         <!-- the unbound SLF4J no-operation (NOP) logger implementation -->
         <dependency>
@@ -139,7 +145,6 @@
             <!--
                 Take care of synchronizing java dependencies and imports in
                 package.json and main.js files.
-                It also creates webpack.config.js if not exists yet.
             -->
             <plugin>
                 <groupId>com.vaadin</groupId>
@@ -151,6 +156,13 @@
                             <goal>prepare-frontend</goal>
                         </goals>
                     </execution>
+                    <execution>
+                        <id>package-for-production</id>
+                        <goals>
+                            <goal>build-frontend</goal>
+                        </goals>
+                        <phase>prepare-package</phase>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>
@@ -158,11 +170,8 @@
 
     <profiles>
         <profile>
-            <!-- Production mode is activated by default -->
+            <!-- Production mode is activated by -Pproduction -->
             <id>production</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
             <build>
                 <plugins>
                     <plugin>
@@ -174,24 +183,11 @@
                                 <goals>
                                     <goal>build-frontend</goal>
                                 </goals>
-                                <phase>compile</phase>
                             </execution>
                         </executions>
                     </plugin>
                 </plugins>
             </build>
-        </profile>
-
-        <profile>
-            <!-- Development mode is activated using -Pdevelopment -->
-            <id>development</id>
-            <dependencies>
-                <!-- Include development dependencies -->
-                <dependency>
-                    <groupId>com.vaadin</groupId>
-                    <artifactId>vaadin-dev</artifactId>
-                </dependency>
-            </dependencies>
         </profile>
 
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <failOnMissingWebXml>false</failOnMissingWebXml>
 
-        <vaadin.version>25.0.0-beta1</vaadin.version>
+        <vaadin.version>25.0-SNAPSHOT</vaadin.version>
         <jetty.version>12.1.2</jetty.version>
     </properties>
 
@@ -88,13 +88,6 @@
             <groupId>com.vaadin</groupId>
             <!-- Replace artifactId with vaadin-core to use only free components -->
             <artifactId>vaadin</artifactId>
-            <!-- Remove the following exclussion if you want to enable Hilla -->
-            <exclusions>
-                <exclusion>
-                    <groupId>com.vaadin</groupId>
-                    <artifactId>hilla-dev</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <!-- Added to provide logging output as Vaadin uses -->
@@ -165,22 +158,11 @@
 
     <profiles>
         <profile>
-            <!-- Production mode is activated using -Pproduction -->
+            <!-- Production mode is activated by default -->
             <id>production</id>
-
-            <dependencies>
-                <!-- Exclude development dependencies from production -->
-                <dependency>
-                    <groupId>com.vaadin</groupId>
-                    <artifactId>vaadin-core</artifactId>
-                    <exclusions>
-                        <exclusion>
-                            <groupId>com.vaadin</groupId>
-                            <artifactId>vaadin-dev</artifactId>
-                        </exclusion>
-                    </exclusions>
-                </dependency>
-            </dependencies>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
             <build>
                 <plugins>
                     <plugin>
@@ -198,6 +180,18 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+
+        <profile>
+            <!-- Development mode is activated using -Pdevelopment -->
+            <id>development</id>
+            <dependencies>
+                <!-- Include development dependencies -->
+                <dependency>
+                    <groupId>com.vaadin</groupId>
+                    <artifactId>vaadin-dev</artifactId>
+                </dependency>
+            </dependencies>
         </profile>
 
         <profile>


### PR DESCRIPTION
Changes Maven configuration to build production package by default with 'mvn package' and run in development mode with 'jetty:run'.

PartOf: vaadin/flow#22715