### PR TITLE
Added a workaround for some tb dependencies affecting optionals

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,9 @@
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-testbench-junit5</artifactId>
             <scope>test</scope>
-            <!-- test deps are always "optional", but may interfere regular transitive optionals if not optional -->
+            <!-- Test-scoped dependencies are always considered "optional", but
+            their transitive dependencies may conflict with those from regular
+            optional dependencies if not explicitly marked as optional here. -->
             <optional>true</optional>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,8 @@
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-testbench-junit5</artifactId>
             <scope>test</scope>
+            <!-- test deps are always "optional", but may interfere regular transitive optionals if not optional -->
+            <optional>true</optional>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
In certain (unresolved) conditions, test dependencies might turn regular optional dependencies into non-optional dependencies.
Marking test dependency optional seems to resolve the issue.

## Type of change

- [x] Bugfix
- [ ] Feature