### PR TITLE
Bump Vaadin version to 25.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <failOnMissingWebXml>false</failOnMissingWebXml>
 
-        <vaadin.version>25.0.0-beta9</vaadin.version>
+        <vaadin.version>25.0.0</vaadin.version>
         <jetty.version>12.1.2</jetty.version>
     </properties>
 


### PR DESCRIPTION
## Summary
- Updates Vaadin version from 25.0.0-beta9 to 25.0.0 GA

## Test plan
- Build completes successfully with new version